### PR TITLE
docs(sentio-network): fix stale gas token and indexer JSON-RPC port

### DIFF
--- a/docs/Introduction/sentio-network/access-the-network.md
+++ b/docs/Introduction/sentio-network/access-the-network.md
@@ -71,7 +71,7 @@ Then upload processor with your operator private key (recommended) or private ke
 PRIVATE_KEY=<OPERATOR_PRIVATE_KEY> \
 yarn sentio upload --sentio-network testnet --required-chain-id 1 --no-platform --owner=<OWNER_PUBLIC_KEY>
 
-# Limitation: you need also transfer a small amount of ETH to your operator address
+# Limitation: you need also transfer a small amount of native $ST to your operator address (for gas)
 # though this limitation will be lift soon, we'll only require ST be deposited into Billing contract
 
 ```
@@ -156,10 +156,10 @@ Processor status could be view and managed at [Network Hub](https://testnet-netw
 
 <Image align="center" width="80% " src="https://files.readme.io/bb094f47924191aa5ace16998c1381963267375737e44bc04c7bf52ad835ab86-image.png" />
 
-Each indexer node exposes a small JSON-RPC server on port `10002` for inspecting processor execution. Hit any node — if the processor isn't local to that node, the request is forwarded to whichever indexer hosts it. Method semantics are documented in [Compute Network](compute-network#node-json-rpc).
+Each indexer node exposes a small JSON-RPC server on its compute-node RPC port (advertised via `IndexerRegistry`) for inspecting processor execution. Hit any node — if the processor isn't local to that node, the request is forwarded to whichever indexer hosts it. Method semantics are documented in [Compute Network](compute-network#node-json-rpc).
 
 ```shell
-INDEXER_HOST=<individual indexer host>:10002
+INDEXER_HOST=<individual indexer host>:<compute-node-rpc-port>   # port advertised via IndexerRegistry
 # or using gateway which is compute RPC only endpoint  
 # INDEXER_HOST=https://testnet-compute-gateway.sentio.xyz
 

--- a/docs/Introduction/sentio-network/compute-network.md
+++ b/docs/Introduction/sentio-network/compute-network.md
@@ -42,7 +42,7 @@ Indexers advertise their capabilities (supported chains, hardware tier, region) 
 
 ## Node JSON-RPC
 
-Every indexer exposes a JSON-RPC server on port `10002` for inspecting processor execution. The endpoint is location-transparent: hitting any indexer for a processor not local to it forwards the request to whichever indexer hosts the processor.
+Every indexer exposes a JSON-RPC server on its compute-node RPC port (advertised via `IndexerRegistry`) for inspecting processor execution. The endpoint is location-transparent: hitting any indexer for a processor not local to it forwards the request to whichever indexer hosts the processor.
 
 | Method                   | Returns                                                                                                                                |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Corrects two genuinely-stale items in the **Introduction/sentio-network** docs. **Network naming stays `testnet`** — the legacy testnet (chainId 7892101) has been replaced, so `testnet` now *is* the current network (chainId 7892102), and the docs' existing `testnet` references are already correct.

Verified against **published** tooling: `@sentio/cli@latest` = **4.2.0** maps `--sentio-network testnet` → 7892102 and drops the old chain (`Only "testnet" is supported`); `testnet-v2` remains only as an alias. `@sentio/sdk@latest` = 4.3.0.

## Changes (2 files)
**`access-the-network.md`**
- Operator gas: "transfer a small amount of **ETH**" → "native **$ST**" — the network's native gas token is $ST, so gas can't be paid in ETH.
- Node JSON-RPC: reference the indexer's compute-node RPC port advertised via `IndexerRegistry` instead of a hardcoded legacy port, keeping the compute gateway as the recommended path.

**`compute-network.md`**
- Same fix: the JSON-RPC server is on the compute-node RPC port advertised via `IndexerRegistry`.

## Left unchanged (already correct)
- All `--sentio-network testnet` / `Network: testnet` / "(currently testnet)" references — correct on `@sentio/cli@4.2.0`.
- Gateway / explorer / Network-Hub URLs (canonical bare `testnet-*`; verified `testnet-network.sentio.xyz` serves chainId 7892102).
- The 5 conceptual docs (index, litepaper, storage-network, network-participation, token-economy) — no version-specific values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)