### PR TITLE
docs(sentio-network): fix Step 4 daemon commands, monitor curl vars, and broken anchor

### DIFF
--- a/docs/Introduction/sentio-network/access-the-network.md
+++ b/docs/Introduction/sentio-network/access-the-network.md
@@ -131,17 +131,17 @@ Start the daemon with:
 
 ```shell With Operator Key
 # use binary
-housegate --agent --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --agent-key=$OPERATOR_PRIVATE_KEY --agent-owner=$OWNER_ADDRESS
+storage-network-daemon --sidecar --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --sidecar-key=$OPERATOR_PRIVATE_KEY --sidecar-owner=$OWNER_ADDRESS
 
 # use docker
-docker run -it -p 9001:9001 ghcr.io/housegate/housegate:latest --agent --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --agent-key=$OPERATOR_PRIVATE_KEY --agent-owner=$OWNER_ADDRESS
+docker run -it -p 9001:9001 ghcr.io/sentioxyz/storage-network-daemon:latest --sidecar --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --sidecar-key=$OPERATOR_PRIVATE_KEY --sidecar-owner=$OWNER_ADDRESS
 ```
 ```Text With Owner Key
 # use binary
-housegate --agent --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --agent-key=$OWNER_PRIVATE_KEY
+storage-network-daemon --sidecar --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --sidecar-key=$OWNER_PRIVATE_KEY
 
 # use docker
-docker run -it -p 9001:9001 ghcr.io/housegate/housegate:latest --agent --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --agent-key=$OWNER_PRIVATE_KEY
+docker run -it -p 9001:9001 ghcr.io/sentioxyz/storage-network-daemon:latest --sidecar --state=https://testnet-storage-gateway.sentio.xyz --listen=:9001 --sidecar-key=$OWNER_PRIVATE_KEY
 ```
 
 To avoid using private key in command line, see [Step 2](#step-2-add-an-operator-optional) to add an operator and then use operator's private key.
@@ -183,13 +183,11 @@ PROCESSOR_ID=<your processor ID>
 
 # Processor progress
 curl -s $INDEXER_HOST -H 'Content-Type: application/json' \
-  --data '{"jsonrpc":"2.0","method":"sentio_processorStatus",
-           "params":[{"id":"$PROCESSOR_ID"}],"id":1}'
+  --data '{"jsonrpc":"2.0","method":"sentio_processorStatus","params":[{"id":"'"$PROCESSOR_ID"'"}],"id":1}'
 
 # Recent logs (last 10 entries)
 curl -s $INDEXER_HOST -H 'Content-Type: application/json' \
-  --data '{"jsonrpc":"2.0","method":"sentio_processorLogs",
-           "params":[{"processor_id":"$PROCESSOR_ID","limit":10}],"id":1}'
+  --data '{"jsonrpc":"2.0","method":"sentio_processorLogs","params":[{"processor_id":"'"$PROCESSOR_ID"'","limit":10}],"id":1}'
 ```
 
 <br />

--- a/docs/Introduction/sentio-network/compute-network.md
+++ b/docs/Introduction/sentio-network/compute-network.md
@@ -50,7 +50,7 @@ Every indexer exposes a JSON-RPC server on its compute-node RPC port (advertised
 | `sentio_processorStatus` | Per-chain progress for a processor: processed block / timestamp, state (`CATCHING_UP` / `PROCESSING` / …), SDK version, entity schema. |
 | `sentio_processorLogs`   | Recent driver logs for a processor (paged via `limit` + cursor).                                                                       |
 
-For example invocations, see [Access the Network](access-the-network#monitor-processors-via-node-json-rpc).
+For example invocations, see [Access the Network](access-the-network#monitor-processors).
 
 ## Billing
 


### PR DESCRIPTION
## What this is

I doc-drove **every flow** in `docs/Introduction/sentio-network` against **testnet-v2** (chain 7892102), running the docs' *literal* commands with the *public* tooling they prescribe (`npx @sentio/cli@latest` = 4.2.0, public `storage-network-daemon` v0.2.1, `clickhouse client`). This PR fixes the three inaccuracies that surfaced. Everything else in the docs validated as accurate.

## Fixes in this PR

1. **Step 4 "Connect a query client"** — the download link already points at `storage-network-daemon`, but the start commands still invoked the internal `housegate --agent …` binary and `ghcr.io/housegate/housegate` image (not obtainable by public users). Corrected to `storage-network-daemon --sidecar` with `--sidecar-key`/`--sidecar-owner` and image `ghcr.io/sentioxyz/storage-network-daemon`. Verified against `storage-network-daemon --help` (v0.2.1) and an end-to-end `SHOW DATABASES` / `CREATE`/`INSERT`/`GRANT`/`DROP` run.
2. **Monitor curl examples** — `$PROCESSOR_ID` was inside a single-quoted `--data`, so it never expanded on copy-paste. Reworked to the standard `'"$PROCESSOR_ID"'` idiom. Both `sentio_processorStatus` (param field `id`) and `sentio_processorLogs` (param field `processor_id`) verified working via `https://testnet-compute-gateway.sentio.xyz`.
3. **Broken intra-doc anchor** — `compute-network.md` linked to `access-the-network#monitor-processors-via-node-json-rpc`; the heading is "Monitor processors", so the anchor is `#monitor-processors`.

## Pass/fail per flow (validated against testnet-v2)

| Flow | Result |
|---|---|
| CLI: `--sentio-network testnet` → chain 7892102 (cli 4.2.0) | ✅ Pass |
| Step 3: `create` → `upload` (build/gen/IPFS/create+startProcessor, **sdkVersion 4.3.0** non-empty) | ✅ Pass |
| Step 3: `stop --no-delete` and `stop` (delete) | ✅ Pass |
| Step 4: public `storage-network-daemon --sidecar` flags/startup + `clickhouse client` | ✅ Pass (fixed here) |
| storage-network.md SQL: CREATE/USE/CREATE TABLE/INSERT/SELECT/DELETE/DROP | ✅ Pass |
| storage-network.md permission model: Owner=8, GRANT zero-addr→Read=1, REVOKE→0 | ✅ Pass (on-chain verified) |
| Monitor: `sentio_nodeStatus` / `sentio_processorStatus` / `sentio_processorLogs` | ✅ Pass (curl syntax fixed here) |
| Conceptual docs: $ST token addrs (ETH/BSC), SU costs, permission-bit table, roles, distribution=100% | ✅ Accurate |
| UI flows (platform wizard, Network Hub billing/operator/processor) | ⏳ Not driven — requires an authenticated browser session (URLs resolve 200) |

## Notes (not doc issues, flagged for the team)

- **`@sentio/cli@4.2.0` hardcodes `https://sentio-testnet-v2.rpc.sentio.xyz`, which was returning `rpc node not found` during testing** while the canonical `https://sentio-testnet.rpc.sentio.xyz` served chain 7892102 fine. This is a CLI/infra concern (the docs don't reference the chain RPC host directly), but it will break the CLI-based Step 3 flow until the `-v2` host recovers or the CLI is pointed at the canonical host.
- On **Node 26**, the doc-literal `yarn sentio upload` fails at the default install step (`fuels@0.103.0` engine check; yarn enforces `node ^20||^22||^24`). Works on supported Node (20/22/24). Not a docs bug, but a supported-Node note in the SDK/docs could help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)