### PR TITLE
docs: remove swell-testnet support

### DIFF
--- a/docs/Collect Data/supported-network.md
+++ b/docs/Collect Data/supported-network.md
@@ -1566,7 +1566,6 @@ npx @sentio/cli@latest graph deploy --owner <owner> --name <project name>
 
 </details>
 
->️ Testnet is available at chain ID: 1924, slug swell-testnet .
 ### TAC
 Currently support is for testnet only.
 Chain ID: `2390`, chain slug: `tac-testnet`.


### PR DESCRIPTION
Remove the Swell Testnet (chain ID 1924, slug `swell-testnet`) note from the supported networks page.

Swellchain has been [officially sunset](https://www.swellnetwork.io/post/sunsetting-swellchain-from-l2-to-faro) and the testnet is no longer supported. The Swell Mainnet (1923) section is kept for now and will be removed once the mainnet fully stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)