### PR TITLE
docs: remove moonbeam support

### DIFF
--- a/docs/Collect Data/supported-network.md
+++ b/docs/Collect Data/supported-network.md
@@ -72,7 +72,6 @@ Supported networks and their features are listed below. If you want other chains
 | MEV Commit          | `57173`      | `mev-commit`            | ✓      | ✓            |        |          |
 | Mode Mainnet        | `34443`      | `mode-mainnet`          | ✓      | ✓            |        |          |
 | Monad Mainnet       | `143`        | `monad-mainnet`         | ✓      | ✓            |        |          |
-| Moonbeam            | `1284`       | `moonbeam`              | ✓      | ✓            | ✓      | ✓        |
 | opBNB Mainnet       | `204`        | `opbnb`                 | ✓      | ✓            |        |          |
 | Optimism Mainnet    | `10`         | `optimism`              | ✓      | ✓            |        | ✓        |
 | Plasma Mainnet      | `9745`       | `plasma-mainnet`        | ✓      | ✓            |        |          |
@@ -1127,32 +1126,6 @@ Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart
 </details>
 
 > ️ Testnet is available at chain ID: 10143, slug monad-testnet .
-
-### Moonbeam
-
-Chain ID: `1284`, chain slug: `moonbeam`.
-
-Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart">Quickstart</Anchor>. You could create indexer in either <Anchor label="sentio processor" title="mention" href="processor-basic">sentio processor</Anchor> or <Anchor label="subgraph" title="mention" href="hosted-subgraph">subgraph</Anchor> format.
-
-<details>
-  <summary>Create and upload an example Sentio processor</summary>
-
-  ```
-  npx @sentio/cli@latest create <project name> --chain-type eth --chain-id 1284
-  ...
-  npx @sentio/cli@latest upload
-  ```
-</details>
-
-<details>
-  <summary>Create and deploy an example Subgraph</summary>
-
-  ```
-  npx @sentio/cli@latest graph create <project name> --chain-id 1284
-  ...
-  npx @sentio/cli@latest graph deploy --owner <owner> --name <project name>
-  ```
-</details>
 
 ### opBNB
 

--- a/src/gen-supported-networks.ts
+++ b/src/gen-supported-networks.ts
@@ -32,7 +32,6 @@ const debuggerChains = new Map(Object.entries({
   [EthChainId.BASE]: true,
   [EthChainId.XLAYER_MAINNET]: true,
   [EthChainId.ASTAR]: true,
-  [EthChainId.MOONBEAM]: true,
   [EthChainId.SONEIUM_MAINNET]: true,
   [EthChainId.SONIC_MAINNET]: true,
   [EthChainId.BERACHAIN]: true,
@@ -44,7 +43,6 @@ const traceChain = new Map(Object.entries({
   [EthChainId.ETHEREUM]: true,
   [EthChainId.ASTAR]: true,
   [EthChainId.LINEA]: true,
-  [EthChainId.MOONBEAM]: true,
   [EthChainId.POLYGON]: true,
   [EthChainId.SONEIUM_MAINNET]: true,
   [EthChainId.SONIC_MAINNET]: true


### PR DESCRIPTION
Moonbeam (chain ID 1284, slug `moonbeam`) has been decommissioned. Remove its row from the supported networks table, its detail section, and the `EthChainId.MOONBEAM` entries in the trace/debugger chain maps of the generator script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)