### PR TITLE
docs: remove mev-commit, astar and zklink-nova support

### DIFF
--- a/docs/Collect Data/supported-network.md
+++ b/docs/Collect Data/supported-network.md
@@ -69,7 +69,6 @@ Supported networks and their features are listed below. If you want other chains
 | Mantle              | `5000`       | `mantle`                | ✓      | ✓            |        |          |
 | MegaETH             | `4326`       | `megaeth`               | ✓      | ✓            |        |          |
 | Metis               | `1088`       | `metis`                 | ✓      | ✓            |        |          |
-| MEV Commit          | `57173`      | `mev-commit`            | ✓      | ✓            |        |          |
 | Mode Mainnet        | `34443`      | `mode-mainnet`          | ✓      | ✓            |        |          |
 | Monad Mainnet       | `143`        | `monad-mainnet`         | ✓      | ✓            |        |          |
 | opBNB Mainnet       | `204`        | `opbnb`                 | ✓      | ✓            |        |          |
@@ -1042,32 +1041,6 @@ Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart
 
   ```
   npx @sentio/cli@latest graph create <project name> --chain-id 1088
-  ...
-  npx @sentio/cli@latest graph deploy --owner <owner> --name <project name>
-  ```
-</details>
-
-### MEV Commit
-
-Chain ID: `57173`, chain slug: `mev-commit`.
-
-Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart">Quickstart</Anchor>. You could create indexer in either <Anchor label="sentio processor" title="mention" href="processor-basic">sentio processor</Anchor> or <Anchor label="subgraph" title="mention" href="hosted-subgraph">subgraph</Anchor> format.
-
-<details>
-  <summary>Create and upload an example Sentio processor</summary>
-
-  ```
-  npx @sentio/cli@latest create <project name> --chain-type eth --chain-id 57173
-  ...
-  npx @sentio/cli@latest upload
-  ```
-</details>
-
-<details>
-  <summary>Create and deploy an example Subgraph</summary>
-
-  ```
-  npx @sentio/cli@latest graph create <project name> --chain-id 57173
   ...
   npx @sentio/cli@latest graph deploy --owner <owner> --name <project name>
   ```

--- a/docs/Collect Data/supported-network.md
+++ b/docs/Collect Data/supported-network.md
@@ -37,7 +37,6 @@ Supported networks and their features are listed below. If you want other chains
 | Abstract            | `2741`       | `abstract`              | ✓      | ✓            |        |          |
 | Arbitrum            | `42161`      | `arbitrum-one`          | ✓      | ✓            |        | ✓        |
 | Arc Testnet         | `5042002`    | `arc-testnet`           | ✓      | ✓            |        |          |
-| Astar               | `592`        | `astar`                 | ✓      | ✓            | ✓      | ✓        |
 | Aurora              | `1313161554` | `aurora`                | ✓      | ✓            |        |          |
 | Avalanche           | `43114`      | `avalanche`             | ✓      | ✓            |        |          |
 | B2 Mainnet          | `223`        | `b2-mainnet`            | ✓      | ✓            |        |          |
@@ -88,7 +87,6 @@ Supported networks and their features are listed below. If you want other chains
 | Unichain            | `130`        | `unichain-mainnet`      | ✓      | ✓            |        |          |
 | X Layer Mainnet     | `196`        | `xlayer-mainnet`        | ✓      | ✓            |        | ✓        |
 | Zircuit Mainnet     | `48900`      | `zircuit`               | ✓      | ✓            |        |          |
-| zkLink Nova         | `810180`     | `zklink-nova`           | ✓      | ✓            |        |          |
 | zkSync Era          | `324`        | `zksync-era`            | ✓      | ✓            |        |          |
 
 More on [EVM](evm)
@@ -199,32 +197,6 @@ Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart
 
   ```
   npx @sentio/cli@latest graph create <project name> --chain-id 5042002
-  ...
-  npx @sentio/cli@latest graph deploy --owner <owner> --name <project name>
-  ```
-</details>
-
-### Astar
-
-Chain ID: `592`, chain slug: `astar`.
-
-Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart">Quickstart</Anchor>. You could create indexer in either <Anchor label="sentio processor" title="mention" href="processor-basic">sentio processor</Anchor> or <Anchor label="subgraph" title="mention" href="hosted-subgraph">subgraph</Anchor> format.
-
-<details>
-  <summary>Create and upload an example Sentio processor</summary>
-
-  ```
-  npx @sentio/cli@latest create <project name> --chain-type eth --chain-id 592
-  ...
-  npx @sentio/cli@latest upload
-  ```
-</details>
-
-<details>
-  <summary>Create and deploy an example Subgraph</summary>
-
-  ```
-  npx @sentio/cli@latest graph create <project name> --chain-id 592
   ...
   npx @sentio/cli@latest graph deploy --owner <owner> --name <project name>
   ```
@@ -1557,32 +1529,6 @@ Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart
 </details>
 
 > ️ Testnet is available at chain ID: 48898, slug zircuit-garfield-testnet .
-
-### zkLink Nova
-
-Chain ID: `810180`, chain slug: `zklink-nova`.
-
-Finish Step 1-3 from <Anchor label="Quickstart" title="mention" href="quickstart">Quickstart</Anchor>. You could create indexer in either <Anchor label="sentio processor" title="mention" href="processor-basic">sentio processor</Anchor> or <Anchor label="subgraph" title="mention" href="hosted-subgraph">subgraph</Anchor> format.
-
-<details>
-  <summary>Create and upload an example Sentio processor</summary>
-
-  ```
-  npx @sentio/cli@latest create <project name> --chain-type eth --chain-id 810180
-  ...
-  npx @sentio/cli@latest upload
-  ```
-</details>
-
-<details>
-  <summary>Create and deploy an example Subgraph</summary>
-
-  ```
-  npx @sentio/cli@latest graph create <project name> --chain-id 810180
-  ...
-  npx @sentio/cli@latest graph deploy --owner <owner> --name <project name>
-  ```
-</details>
 
 ### zkSync Era
 


### PR DESCRIPTION
Remove three decommissioned chains from the supported networks documentation:

- **MEV Commit** (chain ID 57173, slug `mev-commit`): the settlement chain was replaced in [mev-commit v1.2.0](https://github.com/primev/mev-commit/releases/tag/v1.2.0) (Sep 2025) and the public RPC no longer responds
- **Astar** (chain ID 592, slug `astar`)
- **zkLink Nova** (chain ID 810180, slug `zklink-nova`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)